### PR TITLE
test4

### DIFF
--- a/.github/workflows/pull-request-prerelease.yml
+++ b/.github/workflows/pull-request-prerelease.yml
@@ -8,26 +8,23 @@ on:
       - release
 
 jobs:
-  get-label-and-author-from-pr:
+  get-label-from-pr:
     runs-on: [ubuntu-latest]
     outputs:
-      should-prerelease: ${{ steps.pr_info.outputs.result.shouldPrerelease }}
-      author: ${{ steps.pr_info.outputs.result.author }}
-      branch-name: ${{ steps.extract-branch.outputs.branch }}
+        should-prerelease: ${{ steps.needs-prerelease.outputs.result }}
+        brach-name: ${{ steps.extract-branch.outputs.branch }}
     steps:
       - uses: actions/github-script@v7
-        id: pr_info
+        id: needs-prerelease
         with:
           script: |
-            const pullRequests = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              commit_sha: context.sha,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-            const pr = pullRequests?.data[0];
-            const shouldPrerelease = pr?.labels?.some((it)=>it.name==='publish pre-release');
-            const author = pr?.user?.login;
-            return { shouldPrerelease, author };
+              return (
+                await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  commit_sha: context.sha,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                })
+              ).data[0]?.labels?.some((it)=>it.name==='publish pre-release');            
           result-encoding: string
       - name: Extract branch name
         env:
@@ -38,22 +35,10 @@ jobs:
   
   echo-results:
     runs-on: [ubuntu-latest]
-    needs: [get-label-and-author-from-pr]
+    needs: [get-label-from-pr]
     steps:
       - name: Echo results
         run: |
-          echo "should-prerelease: ${{ needs.get-label-and-author-from-pr.outputs.should-prerelease }}"
-          echo "author: ${{ needs.get-label-and-author-from-pr.outputs.author }}"
-          echo "branch-name: ${{ needs.get-label-and-author-from-pr.outputs.brach-name }}"
-
-  publish-pre-release:
-    needs: [get-label-and-author-from-pr]
-    name: Publish pre-release
-    if: ${{ needs.get-label-and-author-from-pr.outputs.should-prerelease == 'true' }}        
-    uses: ./.github/workflows/rw-publish-prerelease.yml
-    secrets: inherit
-    permissions:
-      contents: write
-      id-token: write
-    with:      
-      source-branch:  ${{ needs.get-label-and-author-from-pr.outputs.brach-name }}
+          echo "should-prerelease: ${{ needs.get-label-from-pr.outputs.should-prerelease }}"
+          echo "author: ${{ needs.get-label-from-pr.outputs.author }}"
+          echo "branch-name: ${{ needs.get-label-from-pr.outputs.brach-name }}"


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
