### PR TITLE
fix: fix github user name

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -12,3 +12,4 @@ jobs:
         secrets: inherit
         with:
             source-branch: "master"
+            author-name: ${{ github.actor }}

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -12,3 +12,4 @@ jobs:
         secrets: inherit
         with:
             source-branch: "release"
+            author-name: ${{ github.actor }}

--- a/.github/workflows/pull-request-prerelease.yml
+++ b/.github/workflows/pull-request-prerelease.yml
@@ -8,23 +8,36 @@ on:
       - release
 
 jobs:
-  get-label-from-pr:
+  pull-request-info:
     runs-on: [ubuntu-latest]
     outputs:
-        should-prerelease: ${{ steps.needs-prerelease.outputs.result }}
-        brach-name: ${{ steps.extract-branch.outputs.branch }}
+      should-prerelease: ${{ steps.should-prerelease.outputs.result }}
+      author: ${{ steps.author.outputs.result }}
+      branch-name: ${{ steps.extract-branch.outputs.branch }}
     steps:
       - uses: actions/github-script@v7
-        id: needs-prerelease
+        id: should-prerelease
         with:
           script: |
-              return (
-                await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                  commit_sha: context.sha,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                })
-              ).data[0]?.labels?.some((it)=>it.name==='publish pre-release');            
+            const pullRequests = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              commit_sha: context.sha,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            return pullRequests?.data[0]?.labels?.some((it)=>it.name==='publish pre-release');
+          result-encoding: boolean
+      - uses: actions/github-script@v7
+        id: author
+        with:
+          script: |          
+            const pullRequests = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              commit_sha: context.sha,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+    
+            return pullRequests?.data[0]?.user?.login;            
           result-encoding: string
       - name: Extract branch name
         env:
@@ -32,16 +45,16 @@ jobs:
         id: extract-branch
         shell: bash
         run: echo "branch=${CURRENT_REF#refs/heads/}" >> $GITHUB_OUTPUT
-        
 
   publish-pre-release:
-    needs: [get-label-from-pr]
+    needs: [pull-request-info]
     name: Publish pre-release
-    if: ${{ needs.get-label-from-pr.outputs.should-prerelease == 'true' }}        
+    if: ${{ needs.pull-request-info.outputs.should-prerelease == true }}        
     uses: ./.github/workflows/rw-publish-prerelease.yml
     secrets: inherit
     permissions:
       contents: write
       id-token: write
     with:      
-      source-branch:  ${{ needs.get-label-from-pr.outputs.brach-name }}
+      source-branch:  ${{ needs.pull-request-info.outputs.branch-name }}
+      author-name: ${{ needs.pull-request-info.outputs.author }}

--- a/.github/workflows/rw-publish-prerelease.yml
+++ b/.github/workflows/rw-publish-prerelease.yml
@@ -13,6 +13,10 @@ on:
         default: false
         description: "Skip bumping the version"
         type: boolean
+      author-name:
+        required: false
+        description: "The name of the author"
+        type: string
 
 # limit concurrency to one run per branch at a time
 # so that we can run this from master and a release branch at the same time
@@ -70,7 +74,8 @@ jobs:
     runs-on: [ubuntu-latest]
     needs: [bump-version, publish-prerelease]
     steps:
-      - name: Notify to slack
+      - name: Notify to slack with author name
+        if: ${{ inputs.author-name != '' }}
         uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: "#javascript-notifications"
@@ -78,4 +83,13 @@ jobs:
         env:
           RELEASE_VERSION: ${{ needs.bump-version.outputs.version }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          GITHUB_USER: ${{ github.actor }}
+          GITHUB_USER: ${{ inputs.author-name }}
+      - name: Notify to slack with without author name
+        if: ${{ inputs.author-name == '' }}
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          channel-id: "#javascript-notifications"
+          slack-message: "The latest *prerelase* version, *gooddata-ui-sdk@${{ env.RELEASE_VERSION }}*, has been successfully published on NPM. :tada:"
+        env:
+          RELEASE_VERSION: ${{ needs.bump-version.outputs.version }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
JIRA: STL-152

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
